### PR TITLE
chore: version migration with flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,16 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>11.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+            <version>11.13.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -115,7 +125,19 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>10.20.0</version>
+                <configuration>
+                    <url>jdbc:mysql://localhost:3306/pagamentosimplificado</url>
+                    <user>root</user>
+                    <password>senha</password>
+                    <schemas>
+                        <schema>pagamentosimplificado</schema>
+                    </schemas>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/com/picpaysimplificado/domain/user/User.java
+++ b/src/main/java/com/picpaysimplificado/domain/user/User.java
@@ -23,7 +23,6 @@ public class User {
     private String cpf;
     @Column(unique = true)
     private String email;
-    private String password;
     private BigDecimal balance;
     @Enumerated(EnumType.STRING)
     private UserType type;

--- a/src/main/java/com/picpaysimplificado/dtos/UserDTO.java
+++ b/src/main/java/com/picpaysimplificado/dtos/UserDTO.java
@@ -2,7 +2,10 @@ package com.picpaysimplificado.dtos;
 
 import com.picpaysimplificado.domain.user.UserType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.br.CPF;
 
 import java.math.BigDecimal;
@@ -31,11 +34,6 @@ public record UserDTO(
         @Email(message = "E-mail inválido")
         @Schema(example = "joao@gmail.com")
         String email,
-
-        @NotBlank(message = "A senha é obrigatória")
-        @Size(min = 6, message = "A senha deve ter no mínimo 6 caracteres")
-        @Schema(example = "senh@123")
-        String password,
 
         @NotNull(message = "O tipo de usuário é obrigatório")
         @Schema(example = "COMMON")

--- a/src/main/java/com/picpaysimplificado/services/UserService.java
+++ b/src/main/java/com/picpaysimplificado/services/UserService.java
@@ -36,7 +36,6 @@ public class UserService {
                 .lastName(userDTO.lastName())
                 .cpf(userDTO.cpf())
                 .email(userDTO.email())
-                .password(userDTO.password())
                 .balance(userDTO.balance())
                 .type(userDTO.type())
                 .build();

--- a/src/main/resources/db/migration/V001__create_users_table.sql
+++ b/src/main/resources/db/migration/V001__create_users_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE users (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    balance DECIMAL(38,2) DEFAULT NULL,
+    cpf VARCHAR(255) DEFAULT NULL,
+    email VARCHAR(255) DEFAULT NULL,
+    first_name VARCHAR(255) DEFAULT NULL,
+    last_name VARCHAR(255) DEFAULT NULL,
+    type ENUM('COMMON','MERCHANT') DEFAULT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY UK_users_cpf (cpf),
+    UNIQUE KEY UK_users_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V002__create_transactions_table.sql
+++ b/src/main/resources/db/migration/V002__create_transactions_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE transactions (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    amount DECIMAL(38,2) DEFAULT NULL,
+    timestamp DATETIME(6) DEFAULT NULL,
+    receiver_id BIGINT DEFAULT NULL,
+    sender_id BIGINT DEFAULT NULL,
+    PRIMARY KEY (id),
+    KEY FK_transactions_receiver (receiver_id),
+    KEY FK_transactions_sender (sender_id),
+    CONSTRAINT FK_transactions_sender FOREIGN KEY (sender_id) REFERENCES users (id),
+    CONSTRAINT FK_transactions_receiver FOREIGN KEY (receiver_id) REFERENCES users (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## Contexto  
Este MR tem como objetivo adotar o **Flyway** como ferramenta de versionamento e gerenciamento de schema do banco de dados.  
Com isso, removemos a responsabilidade do Hibernate de criar ou atualizar as tabelas automaticamente.

### Alterações realizadas  
- Adicionada a dependência do **Flyway** no projeto (via Maven).  
- Criadas as migrations iniciais para as tabelas:
  - `users`
  - `transactions`  
- Configurado o Spring Boot para utilizar `spring.jpa.hibernate.ddl-auto=validate`, garantindo que o Hibernate apenas valide o schema criado pelo Flyway, sem alterá-lo.  
- Mantidas as anotações JPA nas entidades para que o **mapeamento objeto-relacional** continue funcionando normalmente com o Spring Data JPA.  

### Benefícios  
- Melhor controle de versões e histórico do schema do banco de dados.  
- Maior previsibilidade e segurança em ambientes diferentes (dev, staging, produção).  
- Facilita rollback e evolução incremental da base de dados.  
- Separação de responsabilidades:  
  - **Flyway** → versionamento e criação do schema.  
  - **JPA** → mapeamento e persistência de dados.  

### Próximos passos  
- Adicionar novas migrations sempre que houver alteração no schema.  
- Padronizar o nome dos arquivos de migration conforme convenção `V{versão}__{descrição}.sql`